### PR TITLE
README.md: Add Dependencies Section for Clarity on Xcode Requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 ## Contents
 
 - [Contents](#contents)
+- [Dependencies](#dependencies)
 - [Installation](#installation)
   - [Homebrew Tap](#homebrew-tap)
   - [`go install`](#go-install)
@@ -21,6 +22,9 @@
 - [Usage](#usage)
   - [Example](#example)
 - [LICENSE](#license)
+
+## Dependencies
+- Xcode: Version 15.1 or higher required.
 
 ## Installation
 


### PR DESCRIPTION
### Execution Environment

To provide a clear context for troubleshooting or understanding the situation, the following details outline the execution environment where the issue occurred:

- Operating System: The system was running macOS Sonoma version 14.0.
- Homebrew Version:
Version: 4.2.15
Core Repository: git revision d21dfd3481a, last updated on 2024-03-27
Cask Repository: git revision 1000ae097f, last updated on 2024-03-27
- Xcode Version (before the update): The system had Xcode version 14.3.1 installed, which was identified as outdated when attempting to install mingo.
Please note that the installation process indicated a need to update Xcode to version 15.1 due to an error encountered during the mingo installation.

### What did you do?
I executed the command `$ brew install koki-develop/tap/mingo` to install mingo.

### What did you see happen?
During the installation process, I encountered an error message indicating that my version of Xcode was too outdated. Specifically, the message stated:

```sh
Error: Your Xcode (14.3.1) at /Applications/Xcode.app is too outdated.
Please update to Xcode 15.1 (or delete it).
Xcode can be updated from the App Store.
```

### What did you expect to see?
I expected the installation of mingo to proceed without any issues. However, there was no mention in the README that Xcode 15.1 or later was required for the installation. I anticipated that the README would provide all necessary dependencies and prerequisites to ensure a smooth installation process.
